### PR TITLE
Django3 compatibility

### DIFF
--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.mail import EmailMultiAlternatives
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 
@@ -37,7 +36,6 @@ class MailerMessageManager(models.Manager):
         self.filter(sent=True, last_attempt__lte=delete_before).delete()
 
 
-@python_2_unicode_compatible
 class MailerMessage(models.Model):
     created = models.DateTimeField(_('Created'), auto_now_add=True, auto_now=False,
                                    editable=False, null=True)
@@ -139,7 +137,6 @@ class MailerMessage(models.Model):
             self.save()
 
 
-@python_2_unicode_compatible
 class Attachment(models.Model):
     file_attachment = models.FileField(storage=get_storage(), upload_to=upload_to,
                                        blank=True, null=True)


### PR DESCRIPTION
This PR removes python2_unicode_compatible decorator usage to make django-mail-queue Django 3 compatible. I haven't done much testing as this is the first time I've used django-mail-queue, but it imports and migrates correctly.