### PR TITLE
Django 4.0 compatibility

### DIFF
--- a/mailqueue/admin.py
+++ b/mailqueue/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin, messages
 from django.contrib.messages import add_message
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import MailerMessage, Attachment
 

--- a/mailqueue/models.py
+++ b/mailqueue/models.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.mail import EmailMultiAlternatives
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils import timezone
 
 from . import defaults

--- a/mailqueue/urls.py
+++ b/mailqueue/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import re_path
 from . import views
 
 urlpatterns = [
-    url(r'^clear$', views.clear_sent_messages, name='clear_sent_messages'),
-    url(r'^$', views.run_mail_job, name='run_mail_job'),
+    re_path(r'^clear$', views.clear_sent_messages, name='clear_sent_messages'),
+    re_path(r'^$', views.run_mail_job, name='run_mail_job'),
 ]


### PR DESCRIPTION
#### What's this Pull Request do?

This PR replace removed aliases : 
 - ugettext_lazy (deprecated in Django 3.0, removed from Django 4.0+) with gettext_lazy. 
 - django.conf.urls.url (deprecated in Django 3.1, removed from Django 4.0+) with django.urls.url. 

#### GitHub issues
Issue #11 
